### PR TITLE
Add repo audit

### DIFF
--- a/README.md
+++ b/README.md
@@ -10,6 +10,7 @@ commands such as:
 * Remove a GitHub user from an organization
 * Create a GitHub repo, assign it to a team and hook up repo notifications to
   HipChat *all at once*
+* Audit a local repo to ensure all commits are covered by pull requests
 
 For any successful action, a configured HipChat room is notified, allowing other
 managers to see what's going on in your organization.

--- a/cleric.gemspec
+++ b/cleric.gemspec
@@ -17,6 +17,7 @@ Gem::Specification.new do |s|
 
   s.add_dependency 'ansi', '~> 1.4'
   s.add_dependency 'hipchat-api', '~> 1.0'
+  s.add_dependency 'git', '~> 1.2'
   s.add_dependency 'octokit', '~> 1.24'
   s.add_dependency 'thor', '~> 0.18'
 end

--- a/lib/cleric.rb
+++ b/lib/cleric.rb
@@ -1,4 +1,5 @@
 require 'ansi/code'
+require 'git'
 require 'hipchat-api'
 require 'octokit'
 
@@ -7,5 +8,6 @@ require 'cleric/cli_configuration_provider'
 require 'cleric/console_announcer'
 require 'cleric/hipchat_announcer'
 require 'cleric/github_agent'
+require 'cleric/repo_auditor'
 require 'cleric/repo_manager'
 require 'cleric/user_manager'

--- a/lib/cleric/cli.rb
+++ b/lib/cleric/cli.rb
@@ -19,6 +19,12 @@ module Cleric
   class Repo < Thor
     include CLIDefaults
 
+    desc 'audit <name>', 'Audit the repo for stray commits'
+    def audit(name)
+      auditor = RepoAuditor.new(config, console)
+      auditor.audit_repo(name)
+    end
+
     desc 'create <name>', 'Create the repo <name> and assign a team'
     option :team, type: :numeric, required: true,
       desc: 'The team\'s numerical id'

--- a/lib/cleric/console_announcer.rb
+++ b/lib/cleric/console_announcer.rb
@@ -10,8 +10,17 @@ module Cleric
       write_success("Repo \"#{repo}\" notifications will be sent to chatroom \"#{chatroom}\"")
     end
 
+    def commits_without_pull_requests(repo, commits)
+      write_warning("Repo \"#{repo}\" has the following commits not covered by pull requests:\n" +
+        commits.join("\n"))
+    end
+
     def repo_added_to_team(repo, team)
       write_success("Repo \"#{repo}\" added to team \"#{team}\"")
+    end
+
+    def repo_audit_passed(repo)
+      write_success("Repo \"#{repo}\" passed audit")
     end
 
     def repo_created(repo)
@@ -30,6 +39,10 @@ module Cleric
 
     def write_success(message)
       @io.puts(green { message })
+    end
+
+    def write_warning(message)
+      @io.puts(red { message })
     end
   end
 end

--- a/lib/cleric/console_announcer.rb
+++ b/lib/cleric/console_announcer.rb
@@ -7,32 +7,32 @@ module Cleric
     end
 
     def chatroom_added_to_repo(repo, chatroom)
-      write_success("Repo \"#{repo}\" notifications will be sent to chatroom \"#{chatroom}\"")
+      write_success(%Q[Repo "#{repo}" notifications will be sent to chatroom "#{chatroom}"])
     end
 
     def commits_without_pull_requests(repo, commits)
-      write_warning("Repo \"#{repo}\" has the following commits not covered by pull requests:\n" +
+      write_warning(%Q[Repo "#{repo}" has the following commits not covered by pull requests:\n] +
         commits.join("\n"))
     end
 
     def repo_added_to_team(repo, team)
-      write_success("Repo \"#{repo}\" added to team \"#{team}\"")
+      write_success(%Q[Repo "#{repo}" added to team "#{team}"])
     end
 
     def repo_audit_passed(repo)
-      write_success("Repo \"#{repo}\" passed audit")
+      write_success(%Q[Repo "#{repo}" passed audit])
     end
 
     def repo_created(repo)
-      write_success("Repo \"#{repo}\" created")
+      write_success(%Q[Repo "#{repo}" created])
     end
 
     def user_added_to_team(username, team)
-      write_success("User \"#{username}\" added to team \"#{team}\"")
+      write_success(%Q[User "#{username}" added to team "#{team}"])
     end
 
     def user_removed_from_org(username, email, org)
-      write_success("User \"#{username}\" (#{email}) removed from organization \"#{org}\"")
+      write_success(%Q[User "#{username}" (#{email}) removed from organization "#{org}"])
     end
 
     private

--- a/lib/cleric/github_agent.rb
+++ b/lib/cleric/github_agent.rb
@@ -74,7 +74,7 @@ module Cleric
     end
 
     def create_client
-      client = Octokit::Client.new(credentials)
+      client = Octokit::Client.new(credentials.merge(auto_traversal: true))
     end
 
     def credentials

--- a/lib/cleric/github_agent.rb
+++ b/lib/cleric/github_agent.rb
@@ -48,9 +48,11 @@ module Cleric
     end
 
     # Returns an array of hashes with `:base` and `:head` commit SHA hashes for
-    # every pull request in the named repo.
+    # every merged pull request in the named repo.
     def repo_pull_request_ranges(repo)
-      client.pull_requests(repo, 'closed').map {|pr| { base: pr.base.sha, head: pr.head.sha } }
+      client.pull_requests(repo, 'closed')
+        .reject {|request| request.merged_at.nil? }
+        .map {|request| { base: request.base.sha, head: request.head.sha } }
     end
 
     # Removes the user from the organization.

--- a/lib/cleric/github_agent.rb
+++ b/lib/cleric/github_agent.rb
@@ -47,6 +47,12 @@ module Cleric
       listener.repo_created(name)
     end
 
+    # Returns an array of hashes with `:base` and `:head` commit SHA hashes for
+    # every pull request in the named repo.
+    def repo_pull_request_ranges(repo)
+      client.pull_requests(repo, 'closed').map {|pr| { base: pr.base.sha, head: pr.head.sha } }
+    end
+
     # Removes the user from the organization.
     # @param email [String] The email of the user.
     # @param org [String] The name of the organization.

--- a/lib/cleric/hipchat_announcer.rb
+++ b/lib/cleric/hipchat_announcer.rb
@@ -7,27 +7,27 @@ module Cleric
 
     def chatroom_added_to_repo(repo, chatroom)
       @listener.chatroom_added_to_repo(repo, chatroom)
-      send_message("Repo \"#{repo}\" notifications will be sent to chatroom \"#{chatroom}\"")
+      send_message(%Q[Repo "#{repo}" notifications will be sent to chatroom "#{chatroom}"])
     end
 
     def repo_added_to_team(repo, team)
       @listener.repo_added_to_team(repo, team)
-      send_message("Repo \"#{repo}\" added to team \"#{team}\"")
+      send_message(%Q[Repo "#{repo}" added to team "#{team}"])
     end
 
     def repo_created(repo)
       @listener.repo_created(repo)
-      send_message("Repo \"#{repo}\" created")
+      send_message(%Q[Repo "#{repo}" created])
     end
 
     def user_added_to_team(username, team)
       @listener.user_added_to_team(username, team)
-      send_message("User \"#{username}\" added to team \"#{team}\"")
+      send_message(%Q[User "#{username}" added to team "#{team}"])
     end
 
     def user_removed_from_org(username, email, org)
       @listener.user_removed_from_org(username, email, org)
-      send_message("User \"#{username}\" (#{email}) removed from organization \"#{org}\"", :red)
+      send_message(%Q[User "#{username}" (#{email}) removed from organization "#{org}"], :red)
     end
 
     private

--- a/lib/cleric/repo_auditor.rb
+++ b/lib/cleric/repo_auditor.rb
@@ -15,11 +15,10 @@ module Cleric
     # local copy of the repo.
     def audit_repo(name)
       git = Git.open('.')
-      commits_with_pr = Set.new
-
       ranges = repo_agent.repo_pull_request_ranges(name)
-      ranges.each do |range|
-        commits_with_pr.merge(
+
+      commits_with_pr = ranges.inject(Set.new) do |set, range|
+        set.merge(
           git.log(nil).between(range[:base], range[:head]).map {|commit| commit.sha }
         )
       end

--- a/lib/cleric/repo_auditor.rb
+++ b/lib/cleric/repo_auditor.rb
@@ -1,0 +1,41 @@
+require 'set'
+
+module Cleric
+  class RepoAuditor
+    def initialize(config, listener)
+      @config = config
+      @listener = listener
+    end
+
+    # Identifies commits present in the named repo that do not have
+    # corresponding pull requests. Assumes a working directory is currently a
+    # local copy of the repo.
+    def audit_repo(name)
+      git = Git.open('.')
+      commits_with_pr = Set.new
+
+      ranges = repo_agent.repo_pull_request_ranges(name)
+      ranges.each do |range|
+        commits_with_pr.merge(
+          git.log.between(range[:base], range[:head]).map {|commit| commit.sha }
+        )
+      end
+
+      commits_without_pr = git.log
+        .select {|commit| commit.parents.size == 1 && !commits_with_pr.include?(commit.sha) }
+        .map {|commit| commit.sha }
+
+      if commits_without_pr.empty?
+        @listener.repo_audit_passed(name)
+      else
+        @listener.commits_without_pull_requests(name, commits_without_pr)
+      end
+    end
+
+    private
+
+    def repo_agent
+      @repo_agent ||= @config.repo_agent
+    end
+  end
+end

--- a/lib/cleric/repo_auditor.rb
+++ b/lib/cleric/repo_auditor.rb
@@ -17,11 +17,12 @@ module Cleric
       ranges = repo_agent.repo_pull_request_ranges(name)
       ranges.each do |range|
         commits_with_pr.merge(
-          git.log.between(range[:base], range[:head]).map {|commit| commit.sha }
+          git.log(nil).between(range[:base], range[:head]).map {|commit| commit.sha }
         )
       end
 
-      commits_without_pr = git.log
+      # Passing `nil` to `log` to ensure all commits are returned.
+      commits_without_pr = git.log(nil)
         .select {|commit| commit.parents.size == 1 && !commits_with_pr.include?(commit.sha) }
         .map {|commit| commit.sha }
 

--- a/lib/cleric/repo_auditor.rb
+++ b/lib/cleric/repo_auditor.rb
@@ -1,6 +1,9 @@
 require 'set'
 
 module Cleric
+
+  # Provides services for auditing repositories. Coordinates activities between
+  # local repositories and different service agents, e.g. GitHub.
   class RepoAuditor
     def initialize(config, listener)
       @config = config

--- a/lib/cleric/version.rb
+++ b/lib/cleric/version.rb
@@ -1,3 +1,3 @@
 module Cleric
-  VERSION = '0.2.0'
+  VERSION = '0.3.0'
 end

--- a/spec/cleric/cli_spec.rb
+++ b/spec/cleric/cli_spec.rb
@@ -25,6 +25,9 @@ describe 'Command line' do
     it 'has a create command' do
       cli_help.should include('cleric repo create <name>')
     end
+    it 'has an audit command' do
+      cli_help.should include('cleric repo audit <name>')
+    end
   end
 
   context 'under the "user" command' do
@@ -103,6 +106,23 @@ module Cleric
         end
         it 'delegates creation to the manager' do
           manager.should_receive(:create).with(name, '1234', hash_including(chatroom: 'my_room'))
+        end
+      end
+
+      describe '#audit' do
+        let(:auditor) { mock(RepoAuditor).as_null_object }
+
+        before(:each) { RepoAuditor.stub(:new) { auditor } }
+        after(:each) { repo.audit('my/repo') }
+
+        it 'creates a console announcer' do
+          ConsoleAnnouncer.should_receive(:new).with($stdout)
+        end
+        it 'creates a configured repo auditor' do
+          RepoAuditor.should_receive(:new).with(config, console)
+        end
+        it 'delegates to the auditor' do
+          auditor.should_receive(:audit_repo).with('my/repo')
         end
       end
     end

--- a/spec/cleric/console_announcer_spec.rb
+++ b/spec/cleric/console_announcer_spec.rb
@@ -1,7 +1,6 @@
 require 'spec_helper'
 
 module Cleric
-
   describe ConsoleAnnouncer do
     subject(:announcer) { ConsoleAnnouncer.new(io) }
     let(:io) { mock('IO') }
@@ -10,7 +9,8 @@ module Cleric
       after(:each) { announcer.__send__(method, *opts[:args]) }
 
       it 'sends the message to the configured IO object' do
-        io.should_receive(:puts).with(ANSI::Code.green { opts[:message] })
+        colorizer = opts[:color] || 'green'
+        io.should_receive(:puts).with(ANSI::Code.send(colorizer) { opts[:message] })
       end
     end
 
@@ -20,10 +20,24 @@ module Cleric
         message: 'Repo "a_repo" notifications will be sent to chatroom "a_chatroom"'
     end
 
+    describe '#commits_without_pull_requests' do
+      it_behaves_like 'an announcing method', :commits_without_pull_requests,
+        args: ['a_repo', %w(a list of commits)],
+        message: "Repo \"a_repo\" has the following commits not covered by pull requests:\n" +
+          "a\nlist\nof\ncommits",
+        color: 'red'
+    end
+
     describe '#repo_added_to_team' do
       it_behaves_like 'an announcing method', :repo_added_to_team,
         args: ['a_repo', 'a_team'],
         message: 'Repo "a_repo" added to team "a_team"'
+    end
+
+    describe '#repo_audit_passed' do
+      it_behaves_like 'an announcing method', :repo_audit_passed,
+        args: ['a_repo'],
+        message: 'Repo "a_repo" passed audit'
     end
 
     describe '#repo_created' do

--- a/spec/cleric/github_agent_spec.rb
+++ b/spec/cleric/github_agent_spec.rb
@@ -96,9 +96,14 @@ module Cleric
     end
 
     describe '#repo_pull_request_ranges' do
-      let(:pull_request) { stub('PullRequest', base: base_commit, head: head_commit) }
-      let(:base_commit) { stub('Commit', sha: '123') }
-      let(:head_commit) { stub('Commit', sha: '456') }
+      let(:pull_request) do
+        stub('PullRequest',
+          merged_at: merged_at,
+          base: stub('Commit', sha: '123').as_null_object,
+          head: stub('Commit', sha: '456').as_null_object
+        ).as_null_object
+      end
+      let(:merged_at) { 'some time' }
 
       before(:each) { client.stub(:pull_requests) { [pull_request] } }
 
@@ -109,6 +114,15 @@ module Cleric
       it 'returns the base and head commit SHA hashes' do
         returned = agent.repo_pull_request_ranges('my_org/my_repo')
         returned.should == [ { base: '123', head: '456' } ]
+      end
+
+      context 'when encountering a pull request that has not been merged' do
+        let(:merged_at) { nil }
+
+        it 'does not return that pull request' do
+          returned = agent.repo_pull_request_ranges('my_org/my_repo')
+          returned.should be_empty
+        end
       end
     end
 

--- a/spec/cleric/github_agent_spec.rb
+++ b/spec/cleric/github_agent_spec.rb
@@ -95,6 +95,23 @@ module Cleric
       end
     end
 
+    describe '#repo_pull_request_ranges' do
+      let(:pull_request) { stub('PullRequest', base: base_commit, head: head_commit) }
+      let(:base_commit) { stub('Commit', sha: '123') }
+      let(:head_commit) { stub('Commit', sha: '456') }
+
+      before(:each) { client.stub(:pull_requests) { [pull_request] } }
+
+      it 'gets all the closed pull requests' do
+        client.should_receive(:pull_requests).with('my_org/my_repo', 'closed')
+        agent.repo_pull_request_ranges('my_org/my_repo')
+      end
+      it 'returns the base and head commit SHA hashes' do
+        returned = agent.repo_pull_request_ranges('my_org/my_repo')
+        returned.should == [ { base: '123', head: '456' } ]
+      end
+    end
+
     describe '#remove_user_from_org' do
       let(:users) { [ mock('User', username: 'a_user') ] }
 

--- a/spec/cleric/github_agent_spec.rb
+++ b/spec/cleric/github_agent_spec.rb
@@ -12,7 +12,7 @@ module Cleric
 
     shared_examples :client do
       it 'creates a GitHub client with the configured credentials' do
-        Octokit::Client.should_receive(:new).with(credentials)
+        Octokit::Client.should_receive(:new).with(credentials.merge(auto_traversal: true))
       end
     end
 

--- a/spec/cleric/repo_auditor_spec.rb
+++ b/spec/cleric/repo_auditor_spec.rb
@@ -29,6 +29,8 @@ module Cleric
         Git.should_receive(:open).with('.')
       end
       it 'gets the list of commits in each range from the local repo via the client' do
+        # Expecting three log accesses, one for each range and one for all commits.
+        client.should_receive(:log).with(nil).at_least(3).times
         log.should_receive(:between).with('b', 'd')
         log.should_receive(:between).with('f', 'h')
       end

--- a/spec/cleric/repo_auditor_spec.rb
+++ b/spec/cleric/repo_auditor_spec.rb
@@ -1,0 +1,53 @@
+require 'spec_helper'
+
+module Cleric
+  describe RepoAuditor do
+    subject(:auditor) { RepoAuditor.new(config, listener) }
+    let(:config) { mock('Config', repo_agent: agent).as_null_object }
+    let(:listener) { mock('Listener').as_null_object }
+    let(:agent) { mock('Agent', repo_pull_request_ranges: ranges).as_null_object }
+    let(:ranges) { [{ base: 'b', head: 'd' }, { base: 'f', head: 'h' }] }
+    let(:client) { mock('Client', log: log).as_null_object }
+    let(:log) { ('a'..'i').map {|sha| mock('LogEntry', sha: sha, parents: ['z']) } }
+
+    describe '#audit_repo' do
+      before(:each) do
+        Git.stub(:open) { client }
+        log.stub(:between) do |from, to|
+          (from..to).map {|sha| mock('LogEntry', sha: sha) }
+        end
+
+        # Commits with multiple parents (i.e. merge commits) should be ignored.
+        log.first.stub(:parents) { ['x', 'y'] }
+      end
+      after(:each) { auditor.audit_repo('my/repo') }
+
+      it 'gets the range of commits for all pull requests in the repo via the agent' do
+        agent.should_receive(:repo_pull_request_ranges).with('my/repo')
+      end
+      it 'opens a client for the local repo' do
+        Git.should_receive(:open).with('.')
+      end
+      it 'gets the list of commits in each range from the local repo via the client' do
+        log.should_receive(:between).with('b', 'd')
+        log.should_receive(:between).with('f', 'h')
+      end
+
+      context 'when there are commits outside the given ranges' do
+        it 'notifies the listener of non-merge commits not covered by a pull request' do
+          listener.should_receive(:commits_without_pull_requests).with('my/repo', ['e', 'i'])
+          listener.should_not_receive(:repo_audit_passed)
+        end
+      end
+
+      context 'when there are no commits outside the given ranges' do
+        let(:ranges) { [{ base: 'a', head: 'i' }] }
+
+        it 'notifies the listener that the audit has passed' do
+          listener.should_receive(:repo_audit_passed).with('my/repo')
+          listener.should_not_receive(:commits_without_pull_requests)
+        end
+      end
+    end
+  end
+end


### PR DESCRIPTION
This change introduces the `repo audit` command, which identifies all commits in the named repo that are not covered by a merged pull request. Current limitations include:
- Command must be run within a local copy of the repo (for fast log access). Need command line options to specify working directory and/or clone.
- Looks at entire repo history. Need a command line option to specify an epoch for logging.
- Assumes all pull requests are important, regardless of target branch. Need a command line option to filter to specific target branch but seems usable right now without this.
- Crashes if a pull request contains a head commit no longer present in the repo history. Still investigating how this can come about (suspect history rewriting).

Despite these limitations, I think this change is worth having as it's a good base to build the suggested options onto and it has already turned up some interesting results during testing!

@byoung Interested?
