### PR TITLE
Add repo update command

### DIFF
--- a/lib/cleric/cli.rb
+++ b/lib/cleric/cli.rb
@@ -32,7 +32,15 @@ module Cleric
       desc: 'Send repo notifications to the chatroom with this name or id'
     def create(name)
       manager = RepoManager.new(github, hipchat)
-      manager.create(name, options[:team], { chatroom: options[:chatroom] })
+      manager.create(name, options[:team], chatroom: options[:chatroom])
+    end
+
+    desc 'update <name>', 'Update the repo <name>'
+    option :chatroom, type: :string, required: true,
+      desc: 'Send repo notifications to the chatroom with this name or id'
+    def update(name)
+      manager = RepoManager.new(github, hipchat)
+      manager.update(name, chatroom: options[:chatroom])
     end
   end
 

--- a/lib/cleric/repo_manager.rb
+++ b/lib/cleric/repo_manager.rb
@@ -20,5 +20,10 @@ module Cleric
         @repo_agent.add_chatroom_to_repo(name, chatroom, @listener)
       end
     end
+
+    # Updates an existing repo. Options must include `{ chatroom: 'my_room' }`.
+    def update(name, options)
+      @repo_agent.add_chatroom_to_repo(name, options[:chatroom], @listener)
+    end
   end
 end

--- a/spec/cleric/cli_spec.rb
+++ b/spec/cleric/cli_spec.rb
@@ -22,11 +22,14 @@ describe 'Command line' do
 
   context 'under the "repo" command' do
     let(:cli_command) { 'repo' }
+    it 'has an audit command' do
+      cli_help.should include('cleric repo audit <name>')
+    end
     it 'has a create command' do
       cli_help.should include('cleric repo create <name>')
     end
-    it 'has an audit command' do
-      cli_help.should include('cleric repo audit <name>')
+    it 'has an update command' do
+      cli_help.should include('cleric repo update <name>')
     end
   end
 
@@ -123,6 +126,27 @@ module Cleric
         end
         it 'delegates to the auditor' do
           auditor.should_receive(:audit_repo).with('my/repo')
+        end
+      end
+
+      describe '#update' do
+        let(:name) { 'example_name' }
+        let(:manager) { mock(RepoManager).as_null_object }
+
+        before(:each) do
+          RepoManager.stub(:new) { manager }
+          stub_options_for(repo, chatroom: 'my_room')
+        end
+
+        after(:each) { repo.update(name) }
+
+        include_examples :github_agent_user
+        include_examples :announcers
+        it 'creates a repo manager configured with the agent' do
+          RepoManager.should_receive(:new).with(agent, hipchat)
+        end
+        it 'delegates creation to the manager' do
+          manager.should_receive(:update).with(name, hash_including(chatroom: 'my_room'))
         end
       end
     end

--- a/spec/cleric/repo_manager_spec.rb
+++ b/spec/cleric/repo_manager_spec.rb
@@ -30,5 +30,12 @@ module Cleric
         end
       end
     end
+
+    describe '#update' do
+      it 'tells the agent to add chatroom notification to the repo' do
+        repo_agent.should_receive(:add_chatroom_to_repo).with('my_org/my_repo', 'my_room', listener)
+        manager.update('my_org/my_repo', chatroom: 'my_room')
+      end
+    end
   end
 end


### PR DESCRIPTION
With this change, the command only supports updating the assigned HipChat chat room. Adding as-is because I've had need of this capability.

I've resisted the urge to refactor any of the specs based on recent feedback, e.g. I'm leaving `after` blocks in because there are shared examples that rely on these. Still working out the best way out of that mess.
