### PR TITLE
Fetch latest changes for local repo before audit

### DIFF
--- a/lib/cleric/console_announcer.rb
+++ b/lib/cleric/console_announcer.rb
@@ -27,6 +27,10 @@ module Cleric
       write_success(%Q[Repo "#{repo}" created])
     end
 
+    def repo_fetching_latest_changes
+      write_action("Fetching latest changes for local repo")
+    end
+
     def user_added_to_team(username, team)
       write_success(%Q[User "#{username}" added to team "#{team}"])
     end
@@ -36,6 +40,10 @@ module Cleric
     end
 
     private
+
+    def write_action(message)
+      @io.puts(message)
+    end
 
     def write_success(message)
       @io.puts(green { message })

--- a/lib/cleric/repo_auditor.rb
+++ b/lib/cleric/repo_auditor.rb
@@ -15,6 +15,10 @@ module Cleric
     # local copy of the repo.
     def audit_repo(name)
       git = Git.open('.')
+
+      @listener.repo_fetching_latest_changes
+      git.fetch
+
       ranges = repo_agent.repo_pull_request_ranges(name)
 
       commits_with_pr = ranges.inject(Set.new) do |set, range|

--- a/spec/cleric/console_announcer_spec.rb
+++ b/spec/cleric/console_announcer_spec.rb
@@ -10,7 +10,11 @@ module Cleric
 
       it 'sends the message to the configured IO object' do
         colorizer = opts[:color] || 'green'
-        io.should_receive(:puts).with(ANSI::Code.send(colorizer) { opts[:message] })
+        if colorizer == 'white'
+          io.should_receive(:puts).with(opts[:message])
+        else
+          io.should_receive(:puts).with(ANSI::Code.send(colorizer) { opts[:message] })
+        end
       end
     end
 
@@ -44,6 +48,13 @@ module Cleric
       it_behaves_like 'an announcing method', :repo_created,
         args: ['a_repo'],
         message: 'Repo "a_repo" created'
+    end
+
+    describe '#repo_fetching_latest_changes' do
+      it_behaves_like 'an announcing method', :repo_fetching_latest_changes,
+        args: [],
+        message: 'Fetching latest changes for local repo',
+        color: 'white'
     end
 
     describe '#user_added_to_team' do

--- a/spec/cleric/repo_auditor_spec.rb
+++ b/spec/cleric/repo_auditor_spec.rb
@@ -28,6 +28,12 @@ module Cleric
       it 'opens a client for the local repo' do
         Git.should_receive(:open).with('.')
       end
+      it 'notifies the listener that latest changes are being fetched' do
+        listener.should_receive(:repo_fetching_latest_changes)
+      end
+      it 'fetches the latest changes for the local repo' do
+        client.should_receive(:fetch)
+      end
       it 'gets the list of commits in each range from the local repo via the client' do
         # Expecting three log accesses, one for each range and one for all commits.
         client.should_receive(:log).with(nil).at_least(3).times


### PR DESCRIPTION
Without fetching the latest changes for the local repo, GitHub pull requests may reference commit hashes not present locally, leading to an error.

All tests passing.
