### PR TITLE
Handle obsolete pull requests in repo audit

### DIFF
--- a/lib/cleric/console_announcer.rb
+++ b/lib/cleric/console_announcer.rb
@@ -31,8 +31,8 @@ module Cleric
       write_action("Fetching latest changes for local repo")
     end
 
-    def repo_obsolete_pull_request(base, head)
-      write_warning(%Q[Commits #{base}..#{head} in pull request are no longer present in the repo])
+    def repo_obsolete_pull_request(pr_number, base, head)
+      write_warning(%Q[Commits #{base}..#{head} in pull request #{pr_number} are no longer present in the repo])
     end
 
     def user_added_to_team(username, team)

--- a/lib/cleric/console_announcer.rb
+++ b/lib/cleric/console_announcer.rb
@@ -11,7 +11,7 @@ module Cleric
     end
 
     def commits_without_pull_requests(repo, commits)
-      write_warning(%Q[Repo "#{repo}" has the following commits not covered by pull requests:\n] +
+      write_failure(%Q[Repo "#{repo}" has the following commits not covered by pull requests:\n] +
         commits.join("\n"))
     end
 
@@ -31,6 +31,10 @@ module Cleric
       write_action("Fetching latest changes for local repo")
     end
 
+    def repo_obsolete_pull_request(base, head)
+      write_warning(%Q[Commits #{base}..#{head} in pull request are no longer present in the repo])
+    end
+
     def user_added_to_team(username, team)
       write_success(%Q[User "#{username}" added to team "#{team}"])
     end
@@ -45,12 +49,16 @@ module Cleric
       @io.puts(message)
     end
 
+    def write_failure(message)
+      @io.puts(red { message })
+    end
+
     def write_success(message)
       @io.puts(green { message })
     end
 
     def write_warning(message)
-      @io.puts(red { message })
+      @io.puts(yellow { message })
     end
   end
 end

--- a/lib/cleric/github_agent.rb
+++ b/lib/cleric/github_agent.rb
@@ -52,7 +52,13 @@ module Cleric
     def repo_pull_request_ranges(repo)
       client.pull_requests(repo, 'closed')
         .reject {|request| request.merged_at.nil? }
-        .map {|request| { base: request.base.sha, head: request.head.sha } }
+        .map do |request|
+          {
+            base: request.base.sha,
+            head: request.head.sha,
+            pr_number: request.number
+          }
+        end
     end
 
     # Removes the user from the organization.

--- a/lib/cleric/repo_auditor.rb
+++ b/lib/cleric/repo_auditor.rb
@@ -47,7 +47,7 @@ module Cleric
       begin
         git.log(nil).between(range[:base], range[:head]).map {|commit| commit.sha }
       rescue StandardError => e
-        @listener.repo_obsolete_pull_request(range[:base], range[:head])
+        @listener.repo_obsolete_pull_request(range[:pr_number], range[:base], range[:head])
         []
       end
     end

--- a/lib/cleric/repo_auditor.rb
+++ b/lib/cleric/repo_auditor.rb
@@ -22,9 +22,7 @@ module Cleric
       ranges = repo_agent.repo_pull_request_ranges(name)
 
       commits_with_pr = ranges.inject(Set.new) do |set, range|
-        set.merge(
-          git.log(nil).between(range[:base], range[:head]).map {|commit| commit.sha }
-        )
+        set.merge(commits_in_range(git, range))
       end
 
       # Passing `nil` to `log` to ensure all commits are returned.
@@ -43,6 +41,15 @@ module Cleric
 
     def repo_agent
       @repo_agent ||= @config.repo_agent
+    end
+
+    def commits_in_range(git, range)
+      begin
+        git.log(nil).between(range[:base], range[:head]).map {|commit| commit.sha }
+      rescue StandardError => e
+        @listener.repo_obsolete_pull_request(range[:base], range[:head])
+        []
+      end
     end
   end
 end

--- a/spec/cleric/console_announcer_spec.rb
+++ b/spec/cleric/console_announcer_spec.rb
@@ -59,8 +59,8 @@ module Cleric
 
     describe '#repo_obsolete_pull_request' do
       it_behaves_like 'an announcing method', :repo_obsolete_pull_request,
-        args: ['abc', 'def'],
-        message: %Q[Commits abc..def in pull request are no longer present in the repo],
+        args: ['123', 'abc', 'def'],
+        message: %Q[Commits abc..def in pull request 123 are no longer present in the repo],
         color: 'yellow'
     end
 

--- a/spec/cleric/console_announcer_spec.rb
+++ b/spec/cleric/console_announcer_spec.rb
@@ -57,6 +57,13 @@ module Cleric
         color: 'white'
     end
 
+    describe '#repo_obsolete_pull_request' do
+      it_behaves_like 'an announcing method', :repo_obsolete_pull_request,
+        args: ['abc', 'def'],
+        message: %Q[Commits abc..def in pull request are no longer present in the repo],
+        color: 'yellow'
+    end
+
     describe '#user_added_to_team' do
       it_behaves_like 'an announcing method', :user_added_to_team,
         args: ['a_user', 'a_team'],

--- a/spec/cleric/github_agent_spec.rb
+++ b/spec/cleric/github_agent_spec.rb
@@ -100,7 +100,8 @@ module Cleric
         stub('PullRequest',
           merged_at: merged_at,
           base: stub('Commit', sha: '123').as_null_object,
-          head: stub('Commit', sha: '456').as_null_object
+          head: stub('Commit', sha: '456').as_null_object,
+          number: '789'
         ).as_null_object
       end
       let(:merged_at) { 'some time' }
@@ -113,7 +114,7 @@ module Cleric
       end
       it 'returns the base and head commit SHA hashes' do
         returned = agent.repo_pull_request_ranges('my_org/my_repo')
-        returned.should == [ { base: '123', head: '456' } ]
+        returned.should == [ { base: '123', head: '456', pr_number: '789' } ]
       end
 
       context 'when encountering a pull request that has not been merged' do

--- a/spec/cleric/repo_auditor_spec.rb
+++ b/spec/cleric/repo_auditor_spec.rb
@@ -56,6 +56,21 @@ module Cleric
           listener.should_not_receive(:commits_without_pull_requests)
         end
       end
+
+      context 'when a given range no longer exists in the local repo' do
+        let(:ranges) { [{ base: 'p', head: 'q' }, { base: 'a', head: 'i' }] }
+
+        before(:each) do
+          log.stub(:between).with('p', 'q') { raise 'git log error' }
+        end
+
+        it 'notifies the listener of an obsolete range' do
+          listener.should_receive(:repo_obsolete_pull_request).with('p', 'q')
+        end
+        it 'continues execution normally' do
+          listener.should_receive(:repo_audit_passed).with('my/repo')
+        end
+      end
     end
   end
 end

--- a/spec/cleric/repo_auditor_spec.rb
+++ b/spec/cleric/repo_auditor_spec.rb
@@ -58,14 +58,14 @@ module Cleric
       end
 
       context 'when a given range no longer exists in the local repo' do
-        let(:ranges) { [{ base: 'p', head: 'q' }, { base: 'a', head: 'i' }] }
+        let(:ranges) { [{ base: 'p', head: 'q', pr_number: '123' }, { base: 'a', head: 'i' }] }
 
         before(:each) do
           log.stub(:between).with('p', 'q') { raise 'git log error' }
         end
 
         it 'notifies the listener of an obsolete range' do
-          listener.should_receive(:repo_obsolete_pull_request).with('p', 'q')
+          listener.should_receive(:repo_obsolete_pull_request).with('123', 'p', 'q')
         end
         it 'continues execution normally' do
           listener.should_receive(:repo_audit_passed).with('my/repo')


### PR DESCRIPTION
If the repo history has been rewritten, it is possible that GitHub will have pull requests that reference commit hashes that are no longer present in the repo. This change emits a warning if this occurs (instead of crashing).

All tests passing locally.
