### PR TITLE
Handle user not found when removing user from org

### DIFF
--- a/lib/cleric/console_announcer.rb
+++ b/lib/cleric/console_announcer.rb
@@ -39,6 +39,10 @@ module Cleric
       write_success(%Q[User "#{username}" added to team "#{team}"])
     end
 
+    def user_not_found(email)
+      write_failure(%Q[User "#{email}" not found])
+    end
+
     def user_removed_from_org(username, email, org)
       write_success(%Q[User "#{username}" (#{email}) removed from organization "#{org}"])
     end

--- a/lib/cleric/github_agent.rb
+++ b/lib/cleric/github_agent.rb
@@ -67,8 +67,12 @@ module Cleric
     # @param listener [Object] The target of any callbacks.
     def remove_user_from_org(email, org, listener)
       user = client.search_users(email).first
-      client.remove_organization_member(org, user.username)
-      listener.user_removed_from_org(user.username, email, org)
+      if user
+        client.remove_organization_member(org, user.username)
+        listener.user_removed_from_org(user.username, email, org)
+      else
+        listener.user_not_found(email)
+      end
     end
 
     # Verifies that the user's public email matches that given. On failure,

--- a/lib/cleric/hipchat_announcer.rb
+++ b/lib/cleric/hipchat_announcer.rb
@@ -25,6 +25,10 @@ module Cleric
       send_message(%Q[User "#{username}" added to team "#{team}"])
     end
 
+    def user_not_found(email)
+      @listener.user_not_found(email)
+    end
+
     def user_removed_from_org(username, email, org)
       @listener.user_removed_from_org(username, email, org)
       send_message(%Q[User "#{username}" (#{email}) removed from organization "#{org}"], :red)

--- a/spec/cleric/console_announcer_spec.rb
+++ b/spec/cleric/console_announcer_spec.rb
@@ -70,6 +70,13 @@ module Cleric
         message: 'User "a_user" added to team "a_team"'
     end
 
+    describe '#user_not_found' do
+      it_behaves_like 'an announcing method', :user_not_found,
+        args: ['user@example.com'],
+        message: 'User "user@example.com" not found',
+        color: 'red'
+    end
+
     describe '#user_removed_from_org' do
       it_behaves_like 'an announcing method', :user_removed_from_org,
         args: ['a_user', 'user@example.com', 'an_org'],

--- a/spec/cleric/github_agent_spec.rb
+++ b/spec/cleric/github_agent_spec.rb
@@ -143,6 +143,17 @@ module Cleric
         listener.should_receive(:user_removed_from_org)
           .with('a_user', 'user@example.com', 'an_org')
       end
+
+      context 'when the user is not found' do
+        let(:users) { [] }
+
+        it 'notifies the listener of the failure' do
+          listener.should_receive(:user_not_found).with('user@example.com')
+        end
+        it 'does not notify the listener of success' do
+          listener.should_not_receive(:user_removed_from_org)
+        end
+      end
     end
 
     describe '#verify_user_public_email' do

--- a/spec/cleric/hipchat_announcer_spec.rb
+++ b/spec/cleric/hipchat_announcer_spec.rb
@@ -48,6 +48,13 @@ module Cleric
         message: 'User "a_user" added to team "a_team"'
     end
 
+    describe '#user_not_found' do
+      it 'sends the message to upstream listener' do
+        listener.should_receive(:user_not_found).with('user@example.com')
+        announcer.user_not_found('user@example.com')
+      end
+    end
+
     describe '#user_removed_from_org' do
       it_behaves_like :announcing_method, :user_removed_from_org,
         args: ['a_user', 'user@example.com', 'an_org'],


### PR DESCRIPTION
@isaacwong As requested, here's a change that shows an error (rather than an ugly stack dump) if the email given when removing a user is not found.

All tests passing. Happy for @byoung or @glow-mdsol to pick this up instead.
