### PR TITLE
Don't echo input when asking user for their password

### DIFF
--- a/README.md
+++ b/README.md
@@ -112,4 +112,5 @@ hipchat:
 
 * [Andrew Smith](https://github.com/asmith-mdsol)
 * [Geoff Low](https://github.com/glow-mdsol)
+* [Harry Wilkinson](https://github.com/harryw)
 

--- a/lib/cleric/cli_configuration_provider.rb
+++ b/lib/cleric/cli_configuration_provider.rb
@@ -10,7 +10,7 @@ module Cleric
       if github = config['github']
         { login: github['login'], oauth_token: github['oauth_token'] }
       else
-        { login: ask("GitHub login"), password: ask("GitHub password") }
+        { login: ask("GitHub login"), password: ask("GitHub password", silent: true) }
       end
     end
 
@@ -48,9 +48,14 @@ module Cleric
 
     private
 
-    def ask(prompt)
+    def ask(prompt, options={})
       $stdout.print "#{prompt}: "
-      $stdin.readline.chomp
+      if options[:silent]
+        require 'io/console'
+        $stdin.noecho {|io| io.readline}
+      else
+        $stdin.readline
+      end.chomp
     end
 
     def config


### PR DESCRIPTION
I think this may require Ruby 1.9.3+ due to the use of `require 'console/io'`, but I'm not 100% sure.
