### PR TITLE
Extend update repo command to be able to optionally add team to repo

### DIFF
--- a/lib/cleric/cli.rb
+++ b/lib/cleric/cli.rb
@@ -36,11 +36,13 @@ module Cleric
     end
 
     desc 'update <name>', 'Update the repo <name>'
-    option :chatroom, type: :string, required: true,
+    option :chatroom, type: :string,
       desc: 'Send repo notifications to the chatroom with this name or id'
+    option :team, type: :numeric,
+      desc: 'The team\'s numerical id'
     def update(name)
       manager = RepoManager.new(github, hipchat)
-      manager.update(name, chatroom: options[:chatroom])
+      manager.update(name, chatroom: options[:chatroom], team: options[:team])
     end
   end
 

--- a/lib/cleric/cli.rb
+++ b/lib/cleric/cli.rb
@@ -32,7 +32,7 @@ module Cleric
       desc: 'Send repo notifications to the chatroom with this name or id'
     def create(name)
       manager = RepoManager.new(github, hipchat)
-      manager.create(name, options[:team], chatroom: options[:chatroom])
+      manager.create(name, options[:team], options)
     end
 
     desc 'update <name>', 'Update the repo <name>'
@@ -42,7 +42,7 @@ module Cleric
       desc: 'The team\'s numerical id'
     def update(name)
       manager = RepoManager.new(github, hipchat)
-      manager.update(name, chatroom: options[:chatroom], team: options[:team])
+      manager.update(name, options)
     end
   end
 

--- a/lib/cleric/repo_manager.rb
+++ b/lib/cleric/repo_manager.rb
@@ -8,22 +8,34 @@ module Cleric
       @listener = listener
     end
 
-    # Creates a repo.
-    # @param name [String] Name of the repo, e.g. "my_org/my_repo".
-    # @param team [String] Numerical id of the team.
-    # @param options [Hash] Options, e.g. `{ chatroom: 'my_room' }`
     def create(name, team, options)
       @repo_agent.create_repo(name, @listener)
-      @repo_agent.add_repo_to_team(name, team, @listener)
 
-      if chatroom = options[:chatroom]
-        @repo_agent.add_chatroom_to_repo(name, chatroom, @listener)
-      end
+      add_team(name, team)
+      optionally_add_chatroom(name, options)
     end
 
-    # Updates an existing repo. Options must include `{ chatroom: 'my_room' }`.
     def update(name, options)
-      @repo_agent.add_chatroom_to_repo(name, options[:chatroom], @listener)
+      optionally_add_team(name, options)
+      optionally_add_chatroom(name, options)
+    end
+
+    private
+
+    def add_chatroom(repo_name, chatroom)
+      @repo_agent.add_chatroom_to_repo(repo_name, chatroom, @listener)
+    end
+
+    def add_team(repo_name, team)
+      @repo_agent.add_repo_to_team(repo_name, team, @listener)
+    end
+
+    def optionally_add_chatroom(repo_name, options)
+      add_chatroom(repo_name, options[:chatroom]) if options[:chatroom]
+    end
+
+    def optionally_add_team(repo_name, options)
+      add_team(repo_name, options[:team].to_i) if options[:team]
     end
   end
 end

--- a/spec/cleric/cli_spec.rb
+++ b/spec/cleric/cli_spec.rb
@@ -46,12 +46,6 @@ end
 
 module Cleric
   describe CLI do
-    def stub_options_for(obj, options)
-      # Thor classes access their options through the `option` method so the
-      # only option (pun intended) is to mock as follows.
-      obj.stub_chain(:options, :[]) { |opt| options[opt] }
-    end
-
     let(:config) { mock('Config') }
     let(:agent) { mock('GitHub').as_null_object }
     let(:console) { mock(ConsoleAnnouncer) }
@@ -97,7 +91,7 @@ module Cleric
 
         before(:each) do
           RepoManager.stub(:new) { manager }
-          stub_options_for(repo, team: '1234', chatroom: 'my_room')
+          repo.options = { team: '1234', chatroom: 'my_room' }
         end
 
         after(:each) { repo.create(name) }
@@ -136,7 +130,7 @@ module Cleric
 
         before(:each) do
           RepoManager.stub(:new) { manager }
-          stub_options_for(repo, options)
+          repo.options = options
         end
 
         after(:each) { repo.update(name) }
@@ -175,7 +169,7 @@ module Cleric
       end
 
       describe '#create' do
-        before(:each) { stub_options_for(user, team: '1234', email: 'me@example.com') }
+        before(:each) { user.options = { team: '1234', email: 'me@example.com' } }
         after(:each) { user.welcome('a_username') }
 
         include_examples :announcers

--- a/spec/cleric/cli_spec.rb
+++ b/spec/cleric/cli_spec.rb
@@ -56,7 +56,7 @@ module Cleric
     let(:agent) { mock('GitHub').as_null_object }
     let(:console) { mock(ConsoleAnnouncer) }
     let(:hipchat) { mock(HipChatAnnouncer) }
-    
+
     before(:each) do
       CLIConfigurationProvider.stub(:new) { config }
       GitHubAgent.stub(:new) { agent }
@@ -132,10 +132,11 @@ module Cleric
       describe '#update' do
         let(:name) { 'example_name' }
         let(:manager) { mock(RepoManager).as_null_object }
+        let(:options) { { chatroom: 'my_room' } }
 
         before(:each) do
           RepoManager.stub(:new) { manager }
-          stub_options_for(repo, chatroom: 'my_room')
+          stub_options_for(repo, options)
         end
 
         after(:each) { repo.update(name) }
@@ -147,6 +148,14 @@ module Cleric
         end
         it 'delegates creation to the manager' do
           manager.should_receive(:update).with(name, hash_including(chatroom: 'my_room'))
+        end
+
+        context 'when given a team option' do
+          let(:options) { { chatroom: 'my_room', team: '1234' } }
+
+          it 'delegates creation to the manager' do
+            manager.should_receive(:update).with(name, hash_including(team: '1234'))
+          end
         end
       end
     end

--- a/spec/cleric/repo_manager_spec.rb
+++ b/spec/cleric/repo_manager_spec.rb
@@ -17,11 +17,13 @@ module Cleric
       it 'tells the agent to add the repo to the team' do
         repo_agent.should_receive(:add_repo_to_team).with('my_org/my_repo', 123, listener)
       end
+
       context 'when passed a chatroom' do
         it 'tells the agent to add chatroom notification to the repo' do
           repo_agent.should_receive(:add_chatroom_to_repo).with('my_org/my_repo', 'my_room', listener)
         end
       end
+
       context 'when passed a nil chatroom' do
         let(:chatroom) { nil }
 
@@ -32,9 +34,36 @@ module Cleric
     end
 
     describe '#update' do
-      it 'tells the agent to add chatroom notification to the repo' do
-        repo_agent.should_receive(:add_chatroom_to_repo).with('my_org/my_repo', 'my_room', listener)
-        manager.update('my_org/my_repo', chatroom: 'my_room')
+      let(:options) { Hash.new }
+
+      after(:each) { manager.update('my_org/my_repo', options) }
+
+      context 'when passed a team' do
+        let(:options) { { team: '123' } }
+
+        it 'tells the agent to add the repo to the team' do
+          repo_agent.should_receive(:add_repo_to_team).with('my_org/my_repo', 123, listener)
+        end
+      end
+
+      context 'when passed a nil team' do
+        it 'does not tell the agent to add the repo to the team' do
+          repo_agent.should_not_receive(:add_repo_to_team)
+        end
+      end
+
+      context 'when passed a chatroom' do
+        let(:options) { { chatroom: 'my_room' } }
+
+        it 'tells the agent to add chatroom notification to the repo' do
+          repo_agent.should_receive(:add_chatroom_to_repo).with('my_org/my_repo', 'my_room', listener)
+        end
+      end
+
+      context 'when passed a nil chatroom' do
+        it 'does not tell the agent to add chatroom notification to the repo' do
+          repo_agent.should_not_receive(:add_chatroom_to_repo)
+        end
       end
     end
   end


### PR DESCRIPTION
All tests passing. You'd use this feature like this:

```
bundle exec cleric repo update org/my_repo --team=123
```

Includes some refactoring of the CLI spec and the RepoManager class. In the latter case, I've remove the method description comments; I'm now of the opinion that inline method description aren't DRY with respect to the documentation provided by the specs. Also, I hope the code is sufficiently intent-revealing now not to require them.
